### PR TITLE
Full Sync flags removed events with prefix [REMOVED]

### DIFF
--- a/plugins/google-calendar/plugin.js
+++ b/plugins/google-calendar/plugin.js
@@ -623,11 +623,10 @@ class Plugin extends AppPlugin {
      * More reliable than comparing Google's updated timestamp.
      */
     hasContentChanged(existingRecord, newData) {
-        // 1. Jämför titel (Viktigt!)
+
         const currentTitle = existingRecord.text('title') || (existingRecord.getName ? existingRecord.getName() : '');
         if (currentTitle !== newData.title) return true;
 
-        // 2. Jämför enkla textfält
         const fieldsToCompare = ['location', 'status', 'description', 'calendar', 'all_day'];
         for (const field of fieldsToCompare) {
             const current = existingRecord.text(field);
@@ -635,7 +634,6 @@ class Plugin extends AppPlugin {
             if (current !== newVal) return true;
         }
 
-        // 3. Jämför tid (time_period)
         const currentPeriod = existingRecord.prop('time_period');
         if (currentPeriod) {
             const currentStart = currentPeriod.date();


### PR DESCRIPTION
I have something wierd about incremental sync logging unchanged events in SyncHub. Closing pr.

Local events fetched from google calendar now gets a matching google id.
If local event exists, has google id, and matching event is not found in the original google calendar => flags local event as [REMOVED].