### PR TITLE
Addition of datetime timestamps, ulist bullets, task todos, hashtags and datetime for date references to Telegram plugin

### DIFF
--- a/plugins/telegram/README.md
+++ b/plugins/telegram/README.md
@@ -1,41 +1,10 @@
 # Telegram Sync Plugin
 
-Send messages to your personal Telegram bot, and they appear in Thymer - automatically routed to the right place.
-
----
-
-## The following features have been added in this version to the original
-### Timestamps
-- Use proper Thymer datetime segments (interactive/clickable time values)
-- Timezone calculated from browser (accurate local time)
-- Tasks don't show timestamps (cleaner appearance)
-
-### Multi-line Messages
-- First line with timestamp, subsequent lines as bulleted children
-- Lines after tasks become bulleted sub-items
-- Proper ulist type for bullets
-
-### Task Creation
-- Lines starting with [] or TASK create checkbox tasks
-@important flags tasks as important
--  Multiple task lines each become separate tasks (no bullets)
-
-### Date Parsing
-- Automatic date detection: @tomorrow, @today, @Jan 15, 2026-01-15, 15/01
-- @ prefix removes date text, keeps date segment (clean)
-- Dates work on all lines (tasks, regular text, bullets)
-
-### Hashtags
-- #tag creates clickable, searchable hashtags
-- Works in tasks, text, and bullets
-- Supports hyphens: #project-alpha, #Q1-planning
-
----
+Send messages to your personal Telegram bot, and they appear in Thymer - automatically routed with task creation, date parsing, and hashtag support.
 
 ## Setup
 
 ### 1. Create Your Bot
-
 1. Open Telegram and message [@BotFather](https://t.me/botfather)
 2. Send `/newbot`
 3. Follow the prompts to name your bot
@@ -56,25 +25,76 @@ Messages are automatically routed based on content:
 
 | You Send | Destination |
 |----------|-------------|
-| `Quick thought` | Journal: **01:23** Quick thought |
-| Multi-line text | Journal with indented children |
+| `Quick thought` | Journal: **14:30** Quick thought |
+| `[] Buy groceries` | Journal: ☐ Buy groceries |
+| `[] Call dentist @tomorrow` | Journal: ☐ Call dentist Mon Jan 19 |
+| `[] Fix bug @important` | Journal: ⚠ Fix bug |
+| Multi-line text | Journal with indented and bulleted children |
 | `# Markdown heading` | Captures collection (with Journal ref) |
 | `https://article.com` | Captures collection (URL stored) |
 | `github.com/user/repo/issues/42` | Journal (future: Issues collection) |
-| Photo + caption | Journal: **01:23** [Photo] caption |
+| Photo + caption | Journal: **14:30** [Photo] caption |
 
-### Multi-line Messages
+## Task Creation
 
+Lines starting with `[]` or `TASK` create checkbox tasks:
+
+```
+[] Buy groceries
+[] Call dentist
+[] Review PR
+```
+
+**Result:** Three separate tasks in your Journal (no timestamps, no bullets).
+
+### Task Features
+
+- **@important** - Marks task as important
+- **Date parsing** - Automatically extracts dates
+- **Sub-items** - Lines after a task become bulleted children
+
+## Date Parsing
+
+Dates are automatically detected and added as Thymer date segments:
+
+| Format | Example |
+|--------|---------|
+| Relative | `@tomorrow`, `@today` |
+| Named months | `Jan 15`, `@February 28` |
+| ISO | `2026-01-15` |
+| Slash | `15/01`, `01/15` |
+
+Dates work on all lines - tasks, regular text, and bullet points.
+
+## Hashtags
+
+Hashtags are clickable, searchable tags:
+
+## Multi-line Messages
+
+### Regular Notes
 ```
 First line
 Second line
 Third line
 ```
 
-Becomes a Journal entry with children:
-- **01:23** First line
+**Result:**
+- **14:30** First line
   - Second line
   - Third line
+
+### Tasks with Notes
+```
+[] Main task
+Detail one
+Detail two
+```
+
+**Result:**
+☐ Main task
+  - Detail one
+  - Detail two
 
 ### Markdown Documents
 
@@ -115,47 +135,40 @@ The `last_offset` is automatically updated after each sync.
 ## Troubleshooting
 
 ### "Not configured"
-
 Make sure the Token field has your bot token from BotFather.
 
 ### Messages not appearing
-
 - Check the bot token is correct
 - Try sending a test message to your bot
 - Check Sync Hub logs for errors
 
 ### Duplicate messages
-
 The `last_offset` tracks processed messages. If corrupted, you might see duplicates. Fix by removing `last_offset` from config.
 
 ### "No sync function for: telegram-sync"
-
 The Sync Hub record exists but the plugin's sync function isn't registered. Check:
-
 1. **Plugin enabled?** Go to Plugins panel → ensure Telegram is enabled (not just installed)
-
 2. **Check console for registration:**
    ```
    [SyncHub] Registered plugin: telegram-sync (N total)
    ```
    If missing, the plugin never registered.
-
 3. **Check load order:** Look for these messages in order:
    ```
    [SyncHub] Ready, dispatching synchub-ready event
    [SyncHub] Registered plugin: telegram-sync
    ```
-
 4. **JavaScript errors?** Red errors during load prevent registration.
-
 5. **Force re-registration:** In console:
    ```javascript
    window.dispatchEvent(new CustomEvent('synchub-ready'))
    ```
-
 6. **Reload the plugin:** Disable → wait → re-enable
-
 7. **Orphaned record?** If plugin was uninstalled, delete the "Telegram" record from Sync Hub collection, then reinstall.
+
+## Version
+
+Current version: v1.3.0
 
 ## Future Features
 
@@ -164,5 +177,4 @@ The Sync Hub record exists but the plugin's sync function isn't registered. Chec
 - [ ] iCal link parsing → Calendar collection
 - [ ] Photo storage → Captures with embedded image
 - [ ] Voice message transcription
-- [ ] `/task` command for creating tasks
 - [ ] Two-way: notifications from Thymer → Telegram

--- a/plugins/telegram/README.md
+++ b/plugins/telegram/README.md
@@ -2,6 +2,36 @@
 
 Send messages to your personal Telegram bot, and they appear in Thymer - automatically routed to the right place.
 
+---
+
+## The following features have been added in this version to the original
+### Timestamps
+- Use proper Thymer datetime segments (interactive/clickable time values)
+- Timezone calculated from browser (accurate local time)
+- Tasks don't show timestamps (cleaner appearance)
+
+### Multi-line Messages
+- First line with timestamp, subsequent lines as bulleted children
+- Lines after tasks become bulleted sub-items
+- Proper ulist type for bullets
+
+### Task Creation
+- Lines starting with [] or TASK create checkbox tasks
+@important flags tasks as important
+-  Multiple task lines each become separate tasks (no bullets)
+
+### Date Parsing
+- Automatic date detection: @tomorrow, @today, @Jan 15, 2026-01-15, 15/01
+- @ prefix removes date text, keeps date segment (clean)
+- Dates work on all lines (tasks, regular text, bullets)
+
+### Hashtags
+- #tag creates clickable, searchable hashtags
+- Works in tasks, text, and bullets
+- Supports hyphens: #project-alpha, #Q1-planning
+
+---
+
 ## Setup
 
 ### 1. Create Your Bot


### PR DESCRIPTION
Added to the Telegram plugin

Timestamps
- Use proper Thymer datetime segments rather than plain bolded text. 

Multi-line Messages
- Now uses proper ulist type for bullets

Task Creation
- Lines starting with [] or TASK create checkbox tasks
- '@Important' flags tasks as important (I prob should add all the other flags but I only use important) 
- Tasks don't show timestamps (messes with due dates and looks messy IMHO) 
- Lines after tasks become bulleted sub-items
- However, multiple task lines each become separate tasks (no bullets) 

Date Parsing
- Automatic date detection: `@Tomorrow`, `@today`, `@jan 15`, 2026-01-15, 15/01
- Dates work on all lines (tasks, regular text, bullets) 

Hashtags
- #tag creates clickable, searchable hashtags //---function
